### PR TITLE
Fix prompt and italics!

### DIFF
--- a/src/components/chatbot/Chatbot.tsx
+++ b/src/components/chatbot/Chatbot.tsx
@@ -41,7 +41,7 @@ interface ChatTabProps {
 }
 
 export const BLACKOUT_ASSISTANT_PROMPT_VERSION =
-  "blackout-assistant-2026-08-05-v2";
+  "blackout-assistant-2026-08-05-v3";
 
 /**
  * Keep the locator-excerpt convention identical across both stages so users
@@ -56,13 +56,10 @@ Blackout poetry: the poet starts with an existing passage and creates a poem by 
 Grounding:
 - Work only with the passage provided below. Never reference or substitute any other text.
 - If your response points to specific passage words, refer to the passage words naturally in your response, as you normally would.
-- If your response points to specific passage words, end it with a section titled exactly "Find the words mentioned at:", listing one excerpt per word, each separated by a semi-colon. Each excerpt has two or three nearby passage words, with only the target word bolded. This section should all be one line, without headers. Omit this section if you did not point to a specific word.
+- If your response points to specific passage words, end it with a section titled exactly "Find the words mentioned at:", listing one excerpt per word, each separated by a semi-colon. Each excerpt has two or three nearby passage words called locator words. The target word is bolded and not italicized. The locator words are only italicized. For example, "_before_ **target** _after_". This section should all be one line, without headers. Omit this section if you did not point to a specific word.
 - Quote passage words exactly as written, keep multiple words in passage order, and point to at most five words per response.
-- Use bold only inside the "Find words at:" section.
-- When you point to a specific passage word, show it in a short excerpt containing two or three nearby passage words in total when available. Bold only the word you are pointing to and italicize every surrounding locator word. For example: “*nights are* **clear**” or “*sharp,* **glittering** *sunshine*”. The italicized words are only locators to help the user find the bolded word; they are not part of the suggestion.
-- Quote passage words exactly as written, keep multiple suggested words in passage order, and point to at most five words in a single response.
 - Use bold only for passage words you are pointing to, never for general emphasis.
-- Use italics only for the surrounding locator words in these excerpts, never for general emphasis.
+- Use italics only for the surrounding locator words in these excerpts, never for general emphasis. Write italics with underscores (_like this_), not asterisks — since the target word inside is bolded with asterisks, mixing both on the asterisk character breaks markdown rendering (e.g. "_before **target** after_", never "*before **target** after*").
 - Never suggest a word that does not appear in the passage.
 
 Style and behavior:

--- a/src/components/chatbot/Chatbot.tsx
+++ b/src/components/chatbot/Chatbot.tsx
@@ -9,12 +9,7 @@ import {
 import { FiSend } from "react-icons/fi";
 import { Button, Textarea } from "@chakra-ui/react";
 import { nanoid } from "nanoid";
-import type {
-  ChatOpening,
-  LlmRequestLog,
-  Message,
-  Stage,
-} from "../../types";
+import type { ChatOpening, LlmRequestLog, Message, Stage } from "../../types";
 import { Role } from "../../types";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -36,7 +31,7 @@ interface ChatTabProps {
 }
 
 export const BLACKOUT_ASSISTANT_PROMPT_VERSION =
-  "blackout-assistant-2026-08-04-v1";
+  "blackout-assistant-2026-08-05-v1";
 
 /**
  * Keep the locator-excerpt convention identical across both stages so users
@@ -50,16 +45,17 @@ Blackout poetry: the poet starts with an existing passage and creates a poem by 
 
 Grounding:
 - Work only with the passage provided below. Never reference or substitute any other text.
-- When you point to a specific passage word, show it in a short excerpt containing two or three nearby passage words in total when available. Bold only the word you are pointing to. The unbolded words are only a locator to help the user find it; they are not part of the suggestion.
-- Quote passage words exactly as written, keep multiple suggested words in passage order, and point to at most five words in a single response.
-- Use bold only for passage words you are pointing to, never for general emphasis.
+- If your response points to specific passage words, refer to the passage words naturally in your response, as you normally would.
+- If your response points to specific passage words, end it with a section titled exactly "Find the words mentioned at:", listing one excerpt per word, each separated by a semi-colon. Each excerpt has two or three nearby passage words, with only the target word bolded. This section should all be one line, without headers. Omit this section if you did not point to a specific word.
+- Quote passage words exactly as written, keep multiple words in passage order, and point to at most five words per response.
+- Use bold only inside the "Find words at:" section.
 - Never suggest a word that does not appear in the passage.
 
 Style and behavior:
 - Be warm, natural, and conversational, like a capable writing partner. Avoid ungrounded or sycophantic flattery.
 - Write in complete, everyday sentences. Never compress responses into fragments, labels, or note-style phrasing. If a response is running long, cut options rather than grammar.
 - Use plain language a casual reader can understand on the first pass: prefer feelings and concrete images over literary-analysis terminology unless the user uses that terminology first.
-- The user is working under time pressure. Keep responses under 80 words unless the user explicitly asks for more; most turns should be two to four short sentences.
+- The user is working under time pressure. Keep responses under 80 words, not counting the "Find words at:" section, unless the user explicitly asks for more; most turns should be two to four short sentences.
 - When offering creative directions, give two, or at most three, distinct options. Make each option a complete sentence grounded in something concrete from the passage. A short bulleted list is fine, but do not use headers or tables.
 - End with at most one easy question or next step that the user can answer with a quick choice or reaction.
 - If the user's direction is unclear, ask one brief clarifying question instead of guessing.
@@ -237,13 +233,7 @@ CURRENT SELECTED WORDS (in passage order): ${selectedWords || "none yet"}`,
         timeoutRef.current = null;
       }
     };
-  }, [
-    chatReady,
-    hasShownIdleNudge,
-    hasUserMessageInStage,
-    setMessages,
-    stage,
-  ]);
+  }, [chatReady, hasShownIdleNudge, hasUserMessageInStage, setMessages, stage]);
 
   const sendMessage = async (messageContent?: string) => {
     const content = messageContent || input;
@@ -387,24 +377,22 @@ CURRENT SELECTED WORDS (in passage order): ${selectedWords || "none yet"}`,
           </div>
         ))}
 
-        {chatReady &&
-          !hasUserMessageInStage &&
-          !isLLMLoading && (
-            <div className="mt-4 space-y-2">
-              <p className="text-sm text-gray-600 mb-3">Try asking me:</p>
-              <div className="flex flex-wrap gap-2">
-                {promptSuggestions[stage].map((prompt, index) => (
-                  <button
-                    key={index}
-                    onClick={() => handlePromptSelection(prompt)}
-                    className="px-3 py-2 text-sm bg-gray-100 hover:bg-gray-200 rounded-lg border border-gray-300 transition-colors duration-200 text-left"
-                  >
-                    {prompt}
-                  </button>
-                ))}
-              </div>
+        {chatReady && !hasUserMessageInStage && !isLLMLoading && (
+          <div className="mt-4 space-y-2">
+            <p className="text-sm text-gray-600 mb-3">Try asking me:</p>
+            <div className="flex flex-wrap gap-2">
+              {promptSuggestions[stage].map((prompt, index) => (
+                <button
+                  key={index}
+                  onClick={() => handlePromptSelection(prompt)}
+                  className="px-3 py-2 text-sm bg-gray-100 hover:bg-gray-200 rounded-lg border border-gray-300 transition-colors duration-200 text-left"
+                >
+                  {prompt}
+                </button>
+              ))}
             </div>
-          )}
+          </div>
+        )}
 
         {isLLMLoading && (
           <div>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Chakra's preflight resets `font: inherit` on `*`, which as a side effect
+   wipes out the browser's native `em`/`i` italics. Restore it explicitly so
+   markdown-rendered emphasis (e.g. the chatbot's ReactMarkdown output)
+   actually renders italic. */
+em,
+i {
+  font-style: italic;
+}
+
 @layer components {
   .btn-primary {
     @apply bg-grey text-white w-full md:w-48 py-6 uppercase hover:opacity-70;


### PR DESCRIPTION
Adjusted the prompt to add a "Find words mentioned at:"... section at the end of the message. Also fixed the italics rendering override.

Examples:
<img width="407" height="271" alt="Screenshot 2026-08-07 at 3 24 53 AM" src="https://github.com/user-attachments/assets/881c3af8-8a09-47a7-b535-73bb7f383dc0" />
<img width="398" height="412" alt="Screenshot 2026-08-07 at 3 24 36 AM" src="https://github.com/user-attachments/assets/41682969-b192-4c64-861f-ce91832dac29" />
